### PR TITLE
Improved Windows buildscript reliability and Debug information

### DIFF
--- a/build-windows.rb
+++ b/build-windows.rb
@@ -42,11 +42,11 @@ def get_zynaddsubfx()
     cmd   "mkdir -p pkg"
     cmd   "sh ./z/build-fftw.sh"
     #cmd   "sh ./z/build-jack.sh"
-    cmd   "sh ./z/build-liblo.sh"
-    cmd   "sh ./z/build-mxml.sh"
-    cmd   "sh ./z/build-portaudio.sh"
-    cmd   "sh ./z/build-zlib.sh"
-    cmd   "cp ./libwinpthread* ./pkg/bin/"
+    cmd   " sh ./z/build-liblo.sh"
+    cmd   " sh ./z/build-mxml.sh"
+    cmd   " sh ./z/build-portaudio.sh"
+    cmd   " sh ./z/build-zlib.sh"
+    cmd   " cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll ./pkg/bin/"
 end
 
 def get_zest()
@@ -74,9 +74,12 @@ end
 def build_zynaddsubfx(demo_mode=true)
     mode = demo_mode ? "demo" : "release"
     stage "Building ZynAddSubFX in #{mode} mode"
+    cmd   "rm -rf build-zynaddsubfx-#{mode}"
     cmd   "mkdir -p build-zynaddsubfx-#{mode}"
+    ENV["THIS"]= Dir.pwd
+    cmd   "echo $THIS"
     chdir "build-zynaddsubfx-#{mode}"
-    cmd   "cmake ../zynaddsubfx/ -DCMAKE_TOOLCHAIN_FILE=../z/windows-build.cmake -DGuiModule=zest -DDemoMode=#{demo_mode} -DCMAKE_INSTALL_PREFIX=/usr -DDefaultOutput=pa"
+    cmd   "cmake ../zynaddsubfx/ -DCMAKE_FIND_ROOT_PATH=$THIS/pkg -DCMAKE_TOOLCHAIN_FILE=../z/windows-build.cmake -DGuiModule=zest -DDemoMode=#{demo_mode} -DCMAKE_INSTALL_PREFIX=/usr -DDefaultOutput=pa"
     cmd   "make"
     chdir ".."
 end
@@ -170,6 +173,7 @@ apt_deps = %w{git ruby ruby-dev bison g++-mingw-w64-x86-64 autotools-dev automak
 ################################################################################
 #                          Do The Build                                        #
 ################################################################################
+
 apt_deps.each do |dep|
     apt_install dep
 end

--- a/z/build-fftw.sh
+++ b/z/build-fftw.sh
@@ -1,5 +1,6 @@
+set -e
 wget http://www.fftw.org/fftw-3.3.4.tar.gz
-tar xvf fftw*
+tar xvf fftw*tar.gz --skip-old-files  
 cd fftw*
 ./configure --host=x86_64-w64-mingw32 --prefix=`pwd`/../pkg/ --with-our-malloc --disable-mpi
 make

--- a/z/build-jack.sh
+++ b/z/build-jack.sh
@@ -1,3 +1,4 @@
+set -e
 #wget https://dl.dropboxusercontent.com/u/28869550/jack-1.9.10.tar.bz2
 #tar xvf jack*
 cd jack*

--- a/z/build-liblo.sh
+++ b/z/build-liblo.sh
@@ -1,5 +1,6 @@
+set -e
 wget http://downloads.sourceforge.net/liblo/liblo-0.28.tar.gz
-tar xvf liblo*
+tar xvf liblo*tar.gz --skip-old-files  
 cd liblo*
 ./configure --host=x86_64-w64-mingw32 --prefix=`pwd`/../pkg/ --disable-shared --enable-static
 make

--- a/z/build-mxml.sh
+++ b/z/build-mxml.sh
@@ -1,3 +1,4 @@
+set -e
 wget https://github.com/michaelrsweet/mxml/releases/download/release-2.10/mxml-2.10.tar.gz
 tar xvf mxml-2.10.tar.gz
 cd mxml-2.10

--- a/z/build-portaudio.sh
+++ b/z/build-portaudio.sh
@@ -1,3 +1,4 @@
+set -e
 wget http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz
 rm -rf portaudio
 tar xvf pa_stable*.tgz

--- a/z/build-zlib.sh
+++ b/z/build-zlib.sh
@@ -1,6 +1,7 @@
+set -e
 wget http://downloads.sourceforge.net/libpng/zlib/1.2.7/zlib-1.2.7.tar.gz
 
-tar xvf zlib*
+tar xvf zlib*tar.gz --skip-old-files  
 cd zlib*
 
 CC=x86_64-w64-mingw32-gcc ./configure --prefix=`pwd`/../pkg/ --static

--- a/z/windows-build.cmake
+++ b/z/windows-build.cmake
@@ -1,8 +1,10 @@
 SET(CMAKE_SYSTEM_NAME Windows)
 
+
 SET(CMAKE_C_COMPILER /usr/bin/x86_64-w64-mingw32-gcc)
 SET(CMAKE_CXX_COMPILER /usr/bin/x86_64-w64-mingw32-g++)
 SET(CMAKE_RC_COMPILER /usr/bin/x86_64-w64-mingw32-windres)
 
-SET(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32/ /home/vm/argh/zyn-fusion-build/pkg)
+SET(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32/ $ENV{THIS}/pkg)
+
 #export LD=/usr/bin/x86_64-w64-mingw32-gcc


### PR DESCRIPTION
This should help with the issues people have been having when trying to build zynfusion through Ubuntu. Added "set -e" to the dependecy builders, so that the script stops if a dependecy fails to build. Also made sure that the libwinpthread-1.dll is being copied from the right directory and made the cmake script use a environment variable instead of a fixed path. 
