### PR TITLE
add recursion to the first mkdir that uses /opt/

### DIFF
--- a/build-linux.rb
+++ b/build-linux.rb
@@ -80,7 +80,7 @@ def make_package_from_repos(demo_mode=true)
     cmd   "sudo make install"
     chdir ".."
     cmd "sudo rm -rf /opt/zyn-fusion"
-    cmd "sudo mkdir /opt/zyn-fusion"
+    cmd "sudo mkdir -p /opt/zyn-fusion"
     cmd "sudo chown $(whoami):users /opt/zyn-fusion || true"
     cmd "echo 'Version #{CurrentVersion}' | sudo tee -a /opt/zyn-fusion/VERSION"
     cmd "echo 'Build on'                  | sudo tee -a /opt/zyn-fusion/VERSION"


### PR DESCRIPTION
When the script tried to run sudo mkdir /opt/zyn-fusion for me, it failed, as I do not have a /opt/ path, and the build failed to finish creating the tar. I fixed this by adding -p to the mkdir.