### PR TITLE
Make return code non-zero on failure

### DIFF
--- a/build-linux.rb
+++ b/build-linux.rb
@@ -6,7 +6,7 @@ def cmd(x)
     ret = system(x)
     if(!ret)
         puts "ERROR: '#{x}' failed"
-        exit
+        exit 1
     end
 end
 

--- a/build-rpi3.rb
+++ b/build-rpi3.rb
@@ -6,7 +6,7 @@ def cmd(x)
     ret = system(x)
     if(!ret)
         puts "ERROR: '#{x}' failed"
-        exit
+        exit 1
     end
 end
 

--- a/build-src.rb
+++ b/build-src.rb
@@ -6,7 +6,7 @@ def cmd(x)
     ret = system(x)
     if(!ret)
         puts "ERROR: '#{x}' failed"
-        exit
+        exit 1
     end
 end
 

--- a/build-windows.rb
+++ b/build-windows.rb
@@ -6,7 +6,7 @@ def cmd(x)
     ret = system(x)
     if(!ret)
         puts "ERROR: '#{x}' failed"
-        exit
+        exit 1
     end
 end
 


### PR DESCRIPTION
The build scripts used to return 0 even when they failed. This is now
fixed, the build scipts return 1 on failure.