### PR TITLE
Update build-mingw64.sh

### DIFF
--- a/build-mingw64.sh
+++ b/build-mingw64.sh
@@ -77,14 +77,23 @@ echo "---------Getting Zest---------------------"
 git clone --depth=1 https://github.com/mruby-zest/mruby-zest-build
 cd mruby-zest-build
 git submodule update --init
-cd deps/mruby-dir-glob && git apply ../../../mruby-dir-glob-no-process.patch
-cd ../mruby-io && git apply ../../../mruby-io-libname.patch
-cd ../../mruby && git apply ../../mruby-float-patch.patch
+#cd deps/mruby-dir-glob && git apply ../../../mruby-dir-glob-no-process.patch
+#cd ../mruby-io && git apply ../../../mruby-io-libname.patch
+#cd ../../mruby && git apply ../../mruby-float-patch.patch
+#cd ../
+#Those patches aren't used anymore.
+cd mruby
+git apply ../string-backtraces.diff
 cd ../
+
 ruby rebuild-fcache.rb
-make setupwin
-make builddepwin
+#These make targets have been removed from the makefile, and they aren't used in the ruby version of this build script
+#make setupwin
+#make builddepwin
 cd ..
 
+#The first builds the demo version of the zyn-fusion
 ./z/build-package.sh demo true
+#the second builds the release version.
 ./z/build-package.sh release false
+#comment out the demo version line, if you don't want to build it.


### PR DESCRIPTION
Hello.

I was trying to build zyn-fusion for my windows computer.   I used windows 10 and the MSYS2 mingw64 shell.
 The "build-mingw64.sh" script was out of date and didn't work.   But, I made a few small changes, and now it worked for me.


In order to fix the script, I used the cross-platform building script "build-windows.rb" as a reference to figure out what to change. 


I noticed that there is a another pull request which seems to overhaul the build scripts completely. However, it is large and has currently been under review for a while.  

So, I think that this pull request will help in the meanwhile, since it is a small fix and easily reviewed. It will help people natively build the windows version of zyn-fusion, in the meantime.

-Thanks.



