### PR TITLE
restore default mode

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -1,7 +1,7 @@
 VER	:= 3.0.6-git
 # Mode can be set to either "demo" or "release"
 # TODO: Use two final targets instead of manually setting this flag when invoking `make`
-MODE	:= demo
+MODE	:= release
 ifeq ($(MODE), demo)
 DEMO_MODE	:= true
 else


### PR DESCRIPTION
`README.md` and help section mention `release` as default build mode, but `Common.mk` sets `MODE := demo`. This PR restores `MODE := release`.