### PR TITLE
Updating the native build process for Windows.

### DIFF
--- a/0001-build-fix-build-failures-with-MinGW-new-headers.patch
+++ b/0001-build-fix-build-failures-with-MinGW-new-headers.patch
@@ -1,0 +1,37 @@
+From 3e90bc76b036124c2a94f9bf006af527755271cf Mon Sep 17 00:00:00 2001
+From: erw7 <erw7.github@gmail.com>
+Date: Wed, 3 Nov 2021 00:28:42 +0900
+Subject: [PATCH] build: fix build failures with MinGW new headers
+
+A structure definition was added to mstcpip.h in
+mingw-w64-x86_64-headers-git 9.0.0.6327.f29c1101f,
+which causes a conflict and the build fails. Fix this by
+changing the name in the definition in mstcpip.h.
+
+PR-URL: https://github.com/libuv/libuv/pull/3345
+---
+ include/uv/win.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/include/uv/win.h b/include/uv/win.h
+index f5f1d3a3..5fecf4bf 100644
+--- a/include/uv/win.h
++++ b/include/uv/win.h
+@@ -45,7 +45,14 @@ typedef struct pollfd {
+ #endif
+ 
+ #include <mswsock.h>
++// Disable the typedef in mstcpip.h of MinGW.
++#define _TCP_INITIAL_RTO_PARAMETERS _TCP_INITIAL_RTO_PARAMETERS__AVOID
++#define TCP_INITIAL_RTO_PARAMETERS TCP_INITIAL_RTO_PARAMETERS__AVOID
++#define PTCP_INITIAL_RTO_PARAMETERS PTCP_INITIAL_RTO_PARAMETERS__AVOID
+ #include <ws2tcpip.h>
++#undef _TCP_INITIAL_RTO_PARAMETERS
++#undef TCP_INITIAL_RTO_PARAMETERS
++#undef PTCP_INITIAL_RTO_PARAMETERS
+ #include <windows.h>
+ 
+ #include <process.h>
+-- 
+2.33.0
+

--- a/Makefile.mingw64.mk
+++ b/Makefile.mingw64.mk
@@ -104,8 +104,8 @@ endif
 	
 	
 setup_zest: fetch_zest apply_mruby_patches setup_libuv
-#	cd $(ZEST_PATH) ; \
-#	ruby rebuild-fcache.rb
+	cd $(ZEST_PATH) ; \
+	ruby rebuild-fcache.rb
 
 
 #

--- a/Makefile.mingw64.mk
+++ b/Makefile.mingw64.mk
@@ -31,9 +31,6 @@ build_fftw: $(DEPS_PATH)/fftw
 build_libio: $(DEPS_PATH)/liblo
 	cd $< ; \
 	./configure --prefix=$(PREFIX_PATH) --disable-shared --enable-static
-	#./autogen.sh --prefix=$(PREFIX_PATH) --disable-shared --enable-static
-	#./configure --host=x86_64-w64-mingw32 --prefix=`pwd`/../pkg/ --disable-shared --enable-static
-
 
 	$(MAKE) -C $<
 	$(MAKE) -C $< install
@@ -105,27 +102,11 @@ endif
 	git checkout -- . ; \
 	patch -p1 -N < $(TOP)/0001-build-fix-build-failures-with-MinGW-new-headers.patch
 	
-	#these patches are obsolete, and no longer should be applied.	
-	#cd $(ZEST_PATH)/deps/mruby-dir-glob ; \
-	#git checkout -- . ; \
-	#patch -N < $(TOP)/mruby-dir-glob-no-process.patch
-
-	#cd $(ZEST_PATH)/deps/mruby-io ; \
-	#git checkout -- . ; \
-	#patch -N < $(TOP)/mruby-io-libname.patch
-
-	#cd $(ZEST_PATH)/mruby ; \
-	#git checkout -- . ; \
-	#patch -p1 -N < $(TOP)/mruby-float-patch.patch
-
-
-
+	
 setup_zest: fetch_zest apply_mruby_patches setup_libuv
 #	cd $(ZEST_PATH) ; \
 #	ruby rebuild-fcache.rb
 
-#	$(MAKE) -C $(ZEST_PATH) --always-make builddepwin
-#The above make rule was removed in the cross compile windows makefile, and it causes an error when you run this makefile, so I commented it out here.
 
 #
 # Final Make rule

--- a/Makefile.mingw64.mk
+++ b/Makefile.mingw64.mk
@@ -154,7 +154,7 @@ build_zest:
 ############################ Packing Up Rules ############################
 #
 
-TARGET_ZIP_FILE	:= $(BUILD_PATH)/zyn-fusion-windows-64bit-$(MODE).zip
+TARGET_ZIP_FILE	:= $(BUILD_PATH)/zyn-fusion-windows-64bit-$(VER)-$(MODE).zip
 ZYN_FUSION_OUT	:= $(BUILD_PATH)/zyn-fusion-windows-64bit-$(VER)-$(MODE)
 
 


### PR DESCRIPTION
Hello. This pull request contains several fixes that are needed in order for native building on Windows to work.

I saw this issue ( https://github.com/zynaddsubfx/zyn-fusion-build/issues/86 ) late yesterday, so I decided to take a look at it today.  I was trying to fix that issue but once I fixed it I found a few other build errors. Some of the errors, like the first, happened because some necessary changes weren't applied to "Makefile.mingw64.mk", the native makefile. Some of these changes were applied in Makefile.windows.mk, but had not been applied yet here. 

The changes needed weren't that big, but the issues were probably unrelated to eachother. So, I'm going to explain what I changed for clarity (and documentation I guess):

I'm fairly certain that warning message in that issue, was there when I last built zyn-fusion.  But, I believe that the reason that it prevented compilation this time is because there was a compilation flag set to treat compilation warnings as errors. To fix this, in Makefile.mingw64.mk I changed a line from 
`./autogen.sh --prefix=$(PREFIX_PATH) --disable-shared --enable-static`  to  `./configure --prefix=$(PREFIX_PATH) --disable-shared --enable-static`.  Autogen.sh generates some build & config files for liblo, and I think those were causing the issue. Fortunately the liblo download already comes with pre-generated build files that work fine.

This was the second error:
`patch -N < /c/users/gopal/Desktop/zyn-fusion-build-master/mruby-dir-glob-no-process.patch
/bin/sh: line 3: /c/users/gopal/Desktop/zyn-fusion-build-master/mruby-dir-glob-no-process.patch: No such file or directory
make: *** [Makefile.mingw64.mk:95: apply_mruby_patches] Error 1`
The patch file that it talks about is obsolete and was removed. So I removed that section from the makefile. I actually previously fixed this error in the previous obsolete build system.

This is the third error:
`make -C /c/users/gopal/Desktop/zyn-fusion-build-master/src/mruby-zest-build --always-make builddepwin
make[1]: Entering directory '/c/users/gopal/Desktop/zyn-fusion-build-master/src/mruby-zest-build'
make[1]: *** No rule to make target 'builddepwin'.  Stop.
make[1]: Leaving directory '/c/users/gopal/Desktop/zyn-fusion-build-master/src/mruby-zest-build'
make: *** [Makefile.mingw64.mk:110: setup_zest] Error 2`
To fix this I removed the builddepwin target, which had been removed in other makefiles as well.


The fourth error was caused because of a namespace conflict between libuv (which is a library used by mruby-zest) and the mingw environment. I found these issue and pull requests in the github pages of those projects, and used them to solve the issue: https://github.com/libuv/libuv/pull/3345 & https://github.com/msys2/MINGW-packages/issues/9946
This has been fixed in the latest version of libuv, but mruby-zest is using an older version. I'm not sure if updating libuv would break mruby-zest, and it would be more complex. So, in the meantime, I created a patch from that commit, and added a portion to the makefile which would apply the patch.


The 5th error is that the $(ZYN_FUSION_OUT) variable was missing from the mingw makefile. The 6th error is that in the packaging and zipping part of the build proccess a file path wasn't updated.  I think I copied both solutions from the other makefile. 

**TL;DR:**
Ported some fixes from the crosscompilation makefile to the native makefile, and added a patch for libuv.