### PR TITLE
bundle apk deps as virtual to ease removal

### DIFF
--- a/Install-deps.mk
+++ b/Install-deps.mk
@@ -63,7 +63,7 @@ else ifneq (, $(wildcard /sbin/apk))
 	@echo "  Installing dependencies via apk...                           "
 	@echo ""
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	apk add $(APK_DEPS)
+	apk add -t .zynaddsubfx-deps $(APK_DEPS)
 
 else ifneq (, $(wildcard /bin/dnf))
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
This makes it so apk user can remove deps with `apk del .zynaddsubfx-deps`.

(Obviously removing all deps also deletes some runtime dependencies, but at that point it would make more sense for me to make a proper APKBUILD file)

Tested building. All sources build fine, although some files need `<stdint.h>` now for GCC13.

Runs and installs fine as well.

Thanks.