### PR TITLE
Add support for Void Linux

### DIFF
--- a/Install-deps.mk
+++ b/Install-deps.mk
@@ -21,6 +21,8 @@ DNF_DEPS := git ruby rubygem-rake ruby-devel bison autoconf automake libtool pre
 
 APK_DEPS := gcc g++ wget zlib-dev fftw-dev libuv-static libuv-dev ruby ruby-rake libx11-dev mesa-dev bison cmake liblo-dev mxml-dev
 
+VOID_DEPS := git ruby ruby-devel bison autoconf automake libtool cmake wget pkgconf gcc fftw-devel mxml-devel liblo-devel zlib-devel libX11-devel libuv-devel premake4 MesaLib-devel glu-devel
+
 install_deps:
 # Only allow being invoked within Makefile.<TARGET>.mk
 ifeq (, $(filter Makefile.%.mk,$(MAKEFILE_LIST)))
@@ -73,6 +75,15 @@ else ifneq (, $(wildcard /bin/dnf))
 	@echo ""
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	sudo dnf -y install $(DNF_DEPS)
+
+else ifneq (, $(wildcard /sbin/xbps-install))
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "  Detected Host OS: Void Linux                                 "
+	@echo "  Installing dependencies via xbps-install...                  "
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	sudo xbps-install -y $(VOID_DEPS)
 
 else
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION

I started with the dnf list and chnged the ones that didn't work.

these ones were ok:
	git ruby ruby-devel bison autoconf automake libtool cmake wget pkgconf gcc fftw-devel mxml-devel liblo-devel zlib-devel libX11-devel libuv-devel

these ones I changed:
	rubygem-rake -> provided by ruby-devel
	premake -> premake4
	g++ -> provided by gcc
	mesa-libGL-devel -> MesaLib-devel
	mesa-libGLU-devel -> glu-devel

combined list for void linux:
git ruby ruby-devel bison autoconf automake libtool cmake wget pkgconf gcc fftw-devel mxml-devel liblo-devel zlib-devel libX11-devel libuv-devel premake4 MesaLib-devel glu-devel

I was able to build the all target after this. 