### PR TITLE
Add OpenSUSE Support

### DIFF
--- a/Install-deps.mk
+++ b/Install-deps.mk
@@ -23,6 +23,9 @@ APK_DEPS := gcc g++ wget zlib-dev fftw-dev libuv-static libuv-dev ruby ruby-rake
 
 VOID_DEPS := git ruby ruby-devel bison autoconf automake libtool cmake wget pkgconf gcc fftw-devel mxml-devel liblo-devel zlib-devel libX11-devel libuv-devel premake4 MesaLib-devel glu-devel
 
+ZYPPER_DEPS := git ruby ruby-devel bison autoconf automake libtool cmake wget pkgconf \
+					gcc gcc-c++ fftw3-devel mxml-devel liblo-devel zlib-devel libX11-devel Mesa-devel libuv-devel
+
 install_deps:
 # Only allow being invoked within Makefile.<TARGET>.mk
 ifeq (, $(filter Makefile.%.mk,$(MAKEFILE_LIST)))
@@ -84,6 +87,15 @@ else ifneq (, $(wildcard /sbin/xbps-install))
 	@echo ""
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	sudo xbps-install -y $(VOID_DEPS)
+
+else ifneq (, $(wildcard /bin/zypper))
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "  Detected Host OS: OpenSUSE or directive                  "
+	@echo "  Installing dependencies via zypper...                           "
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	sudo zypper install -y $(ZYPPER_DEPS)
 
 else
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Add build dependencies for OpenSUSE.

Tested on Tumbleweed (main machine) and Leap 16.0 (VM guest) with success for LV2 plugin. Standalone GUI remains unresponsive on either OS.

Have not tested compatibility on other SUSE-based distributions.